### PR TITLE
Update addresses to v2.1.11

### DIFF
--- a/dist/output.json
+++ b/dist/output.json
@@ -22,40 +22,45 @@
   "84532": {
     "clients": {
       "sim-client": {
-        "clientSuffix": "base-sim",
+        "clientSuffix": "base-proofs-2",
         "canonConnFrom": "connection-4",
-        "canonConnTo": "connection-5",
-        "universalChannelId": "channel-40273",
-        "universalChannelAddr": "0x77e69Ab080Fb5d02D4404A6e7cDeC18617A24671",
-        "dispatcherAddr": "0xb7B9f6f8CF00bf9fAe840A608600F47A665080f4"
+        "canonConnTo": "connection-1",
+        "universalChannelId": "channel-40743",
+        "universalChannelAddr": "7264fb109C059Fe56551F712e7B869a8bCA4E9CB",
+        "dispatcherAddr": "0x9fcd52449261F732d017F8BD1CaCDc3dFbcD0361",
+        "feeVault": "0x0411c203dad09377Bc65Ed34B58Fb0b04AeE1445"
       },
       "op-client": {
         "clientSuffix": "base-proofs-2",
         "canonConnFrom": "connection-20",
-        "canonConnTo": "connection-21",
-        "universalChannelId": "channel-40261",
-        "universalChannelAddr": "0x7264fb109C059Fe56551F712e7B869a8bCA4E9CB",
-        "dispatcherAddr": "0x9fcd52449261F732d017F8BD1CaCDc3dFbcD0361"
+        "canonConnTo": "connection-19",
+        "universalChannelId": "channel-40743",
+        "universalChannelAddr": "7264fb109C059Fe56551F712e7B869a8bCA4E9CB",
+        "dispatcherAddr": "0x9fcd52449261F732d017F8BD1CaCDc3dFbcD0361",
+        "feeVault": "0x0411c203dad09377Bc65Ed34B58Fb0b04AeE1445"
       }
     }
   },
   "11155420": {
+
     "clients": {
       "sim-client": {
-        "clientSuffix": "optimism-sim",
+        "clientSuffix": "optimism-proofs-2", 
         "canonConnFrom": "connection-0",
-        "canonConnTo": "connection-1",
-        "universalChannelId": "channel-40272",
-        "universalChannelAddr": "0x3EaD7657C88b1CCf7f538564B2d475CEAEdA575d",
-        "dispatcherAddr": "0x8957494cCD4B085133E9A8d3600b766427d4976a"
+        "canonConnTo": "connection-5",
+        "universalChannelId": "channel-40742",
+        "universalChannelAddr": "0x6c3AD733e52f700b47155e5e09b784b9d324C420",
+        "dispatcherAddr": "0xE2029629f51ab994210d671Dc08b7Ec94899b278",
+        "feeVault":"0x15DDd6D9aF06Feb948D7AC9BDBef34c31C18cB74"
       },
       "op-client": {
         "clientSuffix": "optimism-proofs-2",
         "canonConnFrom": "connection-18",
-        "canonConnTo": "connection-19",
-        "universalChannelId": "channel-40260",
+        "canonConnTo": "connection-21",
+        "universalChannelId": "channel-40742",
         "universalChannelAddr": "0x6c3AD733e52f700b47155e5e09b784b9d324C420",
-        "dispatcherAddr": "0xE2029629f51ab994210d671Dc08b7Ec94899b278"
+        "dispatcherAddr": "0xE2029629f51ab994210d671Dc08b7Ec94899b278",
+        "feeVault":"0x15DDd6D9aF06Feb948D7AC9BDBef34c31C18cB74"
       }
     }
   }


### PR DESCRIPTION
PR to update to deployed v2.1.11 addresses and to update our connection hop config

Note: portprefixes are a bit confusing for now since we have "proofs" in the sim port prefix - this is a consequence of us upgrading our dispatchers to a single contract (and chosing the proof path to do this). I will follow up with another PR to update that config after we update
