### PR TITLE
Add Bob and Mode networks

### DIFF
--- a/chains/eip155-10.json
+++ b/chains/eip155-10.json
@@ -17,19 +17,19 @@
     "decimals": 18
   },
   "infoURL": "https://optimism.io",
-  "shortName": "oeth",
+  "shortName": "optimism",
   "chainId": 10,
   "networkId": 10,
   "explorers": [
     {
-      "name": "etherscan",
-      "url": "https://optimistic.etherscan.io",
-      "standard": "EIP3091"
-    },
-    {
       "name": "blockscout",
       "url": "https://optimism.blockscout.com",
       "icon": "blockscout",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "etherscan",
+      "url": "https://optimistic.etherscan.io",
       "standard": "EIP3091"
     },
     {
@@ -41,7 +41,7 @@
   ],
   "polymer": {
     "chainName": "optimism-mainnet",
-    "dispatcherAddr": "0xF42E19F9e4F5d93FdfA20F1ca78dB5B56789F778",
+    "dispatcherAddr": "0x7b456332e91Edf68B7d5E517085D5b15F9133fb8",
     "dispatcherStartBlock": 124984397,
     "clients": {
       "sim-client": {
@@ -52,7 +52,7 @@
         "universalChannels": [
           {
             "id": "",
-            "addr": "0xDe2532E3Fa17DDfb9f7AFafeeE50607F4e5d161b"
+            "addr": ""
           }
         ]
       },
@@ -63,8 +63,8 @@
         "dispatcherAddr": "",
         "universalChannels": [
           {
-            "id": "",
-            "addr": ""
+            "id": "channel-10",
+            "addr": "0x0d3ed2B0A69a55519Ac249554aA58c5aD08E3174"
           }
         ]
       }

--- a/chains/eip155-34443.json
+++ b/chains/eip155-34443.json
@@ -1,0 +1,28 @@
+{
+  "name": "Mode Mainnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://mainnet.mode.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://mode.network",
+  "chainId": 34443,
+  "explorers": [
+    {
+      "name": "modescout",
+      "url": "https://explorer.mode.network/",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "polymer": {
+    "chainName": "mode",
+    "dispatcherAddr": "",
+    "clients": {}
+  }
+}

--- a/chains/eip155-60808.json
+++ b/chains/eip155-60808.json
@@ -1,0 +1,28 @@
+{
+  "name": "Bob Mainnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.gobob.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://gobob.xyz",
+  "chainId": 60808,
+  "explorers": [
+    {
+      "name": "bobscout",
+      "url": "https://explorer.gobob.xyz/",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "polymer": {
+    "chainName": "bob",
+    "dispatcherAddr": "",
+    "clients": {}
+  }
+}

--- a/chains/eip155-8453.json
+++ b/chains/eip155-8453.json
@@ -22,15 +22,15 @@
   "icon": "base",
   "explorers": [
     {
-      "name": "basescan",
-      "url": "https://basescan.org",
-      "standard": "none"
-    },
-    {
       "name": "basescout",
       "url": "https://base.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
+    },
+    {
+      "name": "basescan",
+      "url": "https://basescan.org",
+      "standard": "none"
     },
     {
       "name": "dexguru",
@@ -42,7 +42,7 @@
   "status": "active",
   "polymer": {
     "chainName": "base-mainnet",
-    "dispatcherAddr": "0xF42E19F9e4F5d93FdfA20F1ca78dB5B56789F778",
+    "dispatcherAddr": "0x7b456332e91Edf68B7d5E517085D5b15F9133fb8",
     "dispatcherStartBlock": 19389139,
     "clients": {
       "sim-client": {
@@ -53,7 +53,7 @@
         "universalChannels": [
           {
             "id": "",
-            "addr": "0xDe2532E3Fa17DDfb9f7AFafeeE50607F4e5d161b"
+            "addr": ""
           }
         ]
       },
@@ -64,8 +64,8 @@
         "dispatcherAddr": "",
         "universalChannels": [
           {
-            "id": "",
-            "addr": ""
+            "id": "channel-11",
+            "addr": "0x0d3ed2B0A69a55519Ac249554aA58c5aD08E3174"
           }
         ]
       }

--- a/dist/output.json
+++ b/dist/output.json
@@ -119,5 +119,39 @@
         ]
       }
     }
+  },
+  "34443": {
+    "name": "Mode Mainnet",
+    "rpc": [
+      "https://mainnet.mode.network"
+    ],
+    "explorers": [
+      {
+        "name": "modescout",
+        "url": "https://explorer.mode.network/",
+        "icon": "blockscout",
+        "standard": "EIP3091"
+      }
+    ],
+    "chainName": "mode",
+    "dispatcherAddr": "",
+    "clients": {}
+  },
+  "60808": {
+    "name": "Bob Mainnet",
+    "rpc": [
+      "https://rpc.gobob.xyz"
+    ],
+    "explorers": [
+      {
+        "name": "bobscout",
+        "url": "https://explorer.gobob.xyz/",
+        "icon": "blockscout",
+        "standard": "EIP3091"
+      }
+    ],
+    "chainName": "bob",
+    "dispatcherAddr": "",
+    "clients": {}
   }
 }


### PR DESCRIPTION
Had to update optimism and mode chain files to match the latest `distOutput.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced configuration for two new mainnets: "Mode Mainnet" and "Bob Mainnet," enhancing network options.
  
- **Updates**
  - Updated existing configurations for the OP Mainnet and Base network, including changes to dispatcher addresses and client settings.
  - Adjusted explorer entries for better organization and visibility.

These changes improve network accessibility and streamline user interactions with the blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->